### PR TITLE
Corrected references to cloud_spec in get_random_number_stream

### DIFF
--- a/atmos_param/radiation/clouds/get_random_number_stream.F90
+++ b/atmos_param/radiation/clouds/get_random_number_stream.F90
@@ -136,17 +136,17 @@ type(cloudrad_control_type), intent(inout) ::  Cldrad_control
 !---------------------------------------------------------------------
         if ( force_use_of_temp_for_seed) then
           use_temp_for_seed = .true.
-          call error_mesg ('cloud_spec_init', &
+          call error_mesg ('random_number_streams_init', &
            'Will use temp as basis for stochastic cloud seed; seed is set true', &
             NOTE)
         else
           use_temp_for_seed = .false.
-          call error_mesg ('cloud_spec_init', &
+          call error_mesg ('random_number_streams_init', &
                ' If model resolution is above c48, it is '// &
-               'HIGHLY RECOMMENDED that you set cloud_spec_nml variable '// &
+               'HIGHLY RECOMMENDED that you set random_number_streams_nml variable '// &
                'force_use_of_temp_for_seed to true to assure '// &
                'reproducibility across pe count and domain layout', NOTE)
-          call error_mesg ('cloud_spec_init', &
+          call error_mesg ('random_number_streams_init', &
                'No action is needed at or below c48 resolution.', NOTE)
         endif
 
@@ -185,12 +185,12 @@ type(cloudrad_control_type), intent(inout) ::  Cldrad_control
                   if (NINT(lats(ii,jj)) == NINT(lats(i,j))) then
                     if (NINT(lons(ii,jj)) == NINT(lons(i,j))) then    
                       Cldrad_control%use_temp_for_seed = .true.
-                      call error_mesg ('cloud_spec_init', &
+                      call error_mesg ('random_number_streams_init', &
                            'Found grid point within 1 degree of  &
                              &another',NOTE)
-                      call error_mesg ('cloud_spec_init', &
+                      call error_mesg ('random_number_streams_init', &
                             'if reproducibility across npes and layout is &
-                           &desired, you must set cloud_spec_nml variable &
+                           &desired, you must set random_number_streams_nml variable &
                            &force_use_of_temp_for_seed to true., and &
                            &restart the model.', NOTE)
                       exit jLoop


### PR DESCRIPTION
Documentation referred to cloud_spec_init and cloud_spec_nml instead of
the correct random_number_streams_{init,nml}
If a user followed the recommendation they may have tried to set
force_use_of_temp_for_seed in cloud_spec_nml where it does not exist.