### PR TITLE
Bugfix, deallocate ocn_depth if allocated

### DIFF
--- a/atmos_shared/tracer_driver/atmos_sulfate.F90
+++ b/atmos_shared/tracer_driver/atmos_sulfate.F90
@@ -1384,7 +1384,7 @@ end subroutine atmos_sulfate_endts
         call interpolator_end (ship_emission_interp) 
         call interpolator_end (aircraft_emission_interp)
 
-        deallocate(ocn_depth)
+        if(allocated(ocn_depth)) deallocate(ocn_depth)
         
         module_is_initialized = .FALSE.
 


### PR DESCRIPTION
- This bug cause some models to crash  at the end of the runs when trying to deallocate an array that is not allocated
- The crash happend particularly with debug mode (-O0) and/or  non-openmp executables.
